### PR TITLE
Allow to pass handle in options

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,11 @@
               <strong>animationCallback(x, y)</strong>
               <span class="description">Called every animation loop, as long as the handle is being dragged or in the process of a sliding animation. The x, y positional values received by this callback reflect the exact position of the handle DOM element, which includes exceeding values (even negative values) when the <em>loose</em> option is set true.</span>
             </li>
+            <li>
+              <span class="type">string</span>
+              <strong>handleClass</strong><span class="default">=handle</span>
+              <span class="description">Custom class of handle element.</span>
+            </li>
           </ul>
 
           <h4>Methods</h4>

--- a/spec/draggingSpec.js
+++ b/spec/draggingSpec.js
@@ -12,6 +12,14 @@ describe("Dragging Dragdealer", function() {
     expect('simple-slider').toHavePosition(100, 0);
   });
 
+  it("should move custom handle along with mouse after pressing", function() {
+    helpers.initDragdealer('custom-handle', {
+      handleClass: 'custom-handle'
+    });
+    helpers.dragTo('custom-handle', 100, 0, 'custom-handle');
+    expect('custom-handle').toHavePosition(100, 0, 'custom-handle');
+  });
+
   it("should not move disabled Dragdealer", function() {
     helpers.initDragdealer('simple-slider', {
       disabled: true

--- a/spec/fixtures/custom-handle.css
+++ b/spec/fixtures/custom-handle.css
@@ -1,0 +1,10 @@
+#custom-handle {
+  width: 500px;
+}
+
+.custom-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  cursor: pointer;
+}

--- a/spec/fixtures/custom-handle.html
+++ b/spec/fixtures/custom-handle.html
@@ -1,0 +1,4 @@
+<div id="custom-handle" class="dragdealer">
+  <div class="handle">This element should not be used as handle</div>
+  <div class="red-bar custom-handle">drag me</div>
+</div>

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -7,9 +7,9 @@ var helpers = {
     return new Dragdealer(dragdealerId, options);
   },
 
-  dragTo: function(dragdealerId, x, y) {
+  dragTo: function(dragdealerId, x, y, handleClass) {
     var $wrapper = $('#' + dragdealerId),
-        $handle = $wrapper.find('.handle'),
+        $handle = $wrapper.find('.' + (handleClass || 'handle')),
         wrapperPosition = $wrapper.offset(),
         handlePosition = $handle.offset();
 
@@ -30,8 +30,8 @@ var helpers = {
     jasmine.Clock.tick(25);
   },
 
-  drop: function(dragdealerId, x, y) {
-    var $handle = $('#' + dragdealerId).find('.handle');
+  drop: function(dragdealerId, x, y, handleClass) {
+    var $handle = $('#' + dragdealerId).find('.' + (handleClass || 'handle'));
     $handle.simulate('mouseup');
   }
 };

--- a/spec/matchers.js
+++ b/spec/matchers.js
@@ -1,7 +1,7 @@
 var matchers = {
 
-  toHavePosition: function(x, y) {
-    var $handle = $('#' + this.actual).find('.handle'),
+  toHavePosition: function(x, y, handleClass) {
+    var $handle = $('#' + this.actual).find('.' + (handleClass || 'handle')),
         position = $handle.position();
     this.message = function() {
       return "Expected " + position.left + ", " + position.top +

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -16,9 +16,9 @@ var Dragdealer = function(wrapper, options) {
    *                  of the wrapper, or the element itself.) The wrapper
    *                  establishes the dragging bounds.
    *
-   *   - The handle: A child of the wrapper element, with a required .handle
-   *                 class. This will be the dragged element, constrained by
-   *                 the wrapper's bounds.
+   *   - The handle: A child of the wrapper element, div with a required
+   *                 .handle class (may be overridden in options). This will be
+   *                 the dragged element, constrained by the wrapper's bounds.
    *
    *
    * The handle can be both smaller or bigger than the wrapper.
@@ -124,6 +124,7 @@ var Dragdealer = function(wrapper, options) {
    *                                 exceeding values (even negative values)
    *                                 when the loose option is set true.
    *
+   *   - string handleClass='handle': Custom class of handle element.
    *
    * Dragdealer also has a few methods to interact with, post-initialization.
    *
@@ -166,25 +167,18 @@ var Dragdealer = function(wrapper, options) {
    *   setValue method expects. Once picked up, the ratios can be scaled and
    *   mapped to match any real-life system of coordinates or dimensions.
    */
+  options = this.applyDefaults(options || {});
   if (typeof(wrapper) == 'string') {
     wrapper = document.getElementById(wrapper);
   }
   if (!wrapper) {
     return;
   }
-  var childElements = wrapper.getElementsByTagName('div'),
-      handle,
-      i;
-  for (i = 0; i < childElements.length; i++) {
-    if (childElements[i].className.match(/(^|\s)handle(\s|$)/)) {
-      handle = childElements[i];
-      break;
-    }
-  }
+  var handle = this.getHandleElement(wrapper, options.handleClass);
   if (!handle) {
     return;
   }
-  this.init(wrapper, handle, options || {});
+  this.init(wrapper, handle, options);
   this.bindEventListeners();
 };
 Dragdealer.prototype = {
@@ -198,13 +192,13 @@ Dragdealer.prototype = {
     loose: false,
     speed: 0.1,
     xPrecision: 0,
-    yPrecision: 0
+    yPrecision: 0,
+    handleClass: 'handle'
   },
   init: function(wrapper, handle, options) {
     this.wrapper = wrapper;
     this.handle = handle;
-    this.options = this.applyDefaults(options);
-
+    this.options = options;
     this.value = {
       prev: [-1, -1],
       current: [options.x || 0, options.y || 0],
@@ -236,6 +230,16 @@ Dragdealer.prototype = {
       }
     }
     return options;
+  },
+  getHandleElement: function(wrapper, handleClass) {
+    var childElements = wrapper.getElementsByTagName('div'),
+        handleClassMatcher = new RegExp('(^|\\s)' + handleClass + '(\\s|$)'),
+        i;
+    for (i = 0; i < childElements.length; i++) {
+      if (handleClassMatcher.test(childElements[i].className)) {
+        return childElements[i];
+      }
+    }
   },
   calculateStepRatios: function() {
     var stepRatios = [];


### PR DESCRIPTION
I'm unsure about the test. Just assumed that the `handle` from options should get `disabled` class if Dragdealer is initialised with `disabled` option set to `true`. Fixes #13.
