### PR TITLE
Wrap module in UMD wrapper

### DIFF
--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -6,6 +6,16 @@
  * http://skidding.mit-license.org
  */
 
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else {
+    // Browser globals
+    root.Dragdealer = factory();
+  }
+}(this, function () {
+
 var Dragdealer = function(wrapper, options) {
   /**
    * Drag-based component that works around two basic DOM elements.
@@ -757,3 +767,7 @@ var Position = {
     return [curleft, curtop];
   }
 };
+
+return Dragdealer;
+
+}));


### PR DESCRIPTION
Not sure if we should test that it works with requirejs (I've tested it locally and it works). 

But if we need to test this, then we should fix current Cursor implementation, that doesn't allow to use two modules on one page, because it overrides `document.onmousemove` and `document.ontouchmove`. So we have to wait until [this commit](https://github.com/skidding/dragdealer/commit/034dcf929375c26076cff734654c8dd521b73d70) gets into master, or fix current Cursor to use something similar to `Dragdealer.prototype.bindEventHandler` or add cross-browser listener from [this example](https://developers.google.com/analytics/devguides/collection/analyticsjs/events#crossbrowser).

Fixes #15.
