### PR TITLE
Use 0.9.7-SNAPSHOT as version of HEAD

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dragdealer",
-  "version": "0.9.6",
+  "version": "0.9.7-SNAPSHOT",
   "description": "Drag-based JavaScript component, embracing endless UI solutions",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Maintaining 0.9.6 as version in package.json is confusion. Only the release commit should use 0.9.6
