### PR TITLE
Allow 'handle' to be any kind of element

### DIFF
--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -245,7 +245,7 @@ Dragdealer.prototype = {
     }
   },
   getHandleElement: function(wrapper, handleClass) {
-    var childElements = wrapper.getElementsByTagName('div'),
+    var childElements = wrapper.children,
         handleClassMatcher = new RegExp('(^|\\s)' + handleClass + '(\\s|$)'),
         i;
     for (i = 0; i < childElements.length; i++) {


### PR DESCRIPTION
Currently the `handle` element can only be a `<div>`, which limits application and hinders a semantic markup. Instead of `wrapper.getElementsByTagName('div')` I simply switched to `wrapper.children` property that returns every element inside the wrapper and since we filtering by `className` there's nothing to worry about.
