### PR TITLE
add enabled/disable step click

### DIFF
--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -208,7 +208,7 @@ Dragdealer.prototype = {
     handleClass: 'handle',
     css3: true,
     activeClass: 'active',
-    enableStepClick: true
+    tapping: true
   },
   init: function() {
     if (this.options.css3) {
@@ -476,18 +476,17 @@ Dragdealer.prototype = {
     }
   },
   startTap: function() {
-    if (this.disabled) {
+    if (this.disabled || !this.options.tapping) {
       return;
     }
+
     this.tapping = true;
     this.setWrapperOffset();
 
-    if (this.options.enableStepClick) {
-      this.setTargetValueByOffset([
-        Cursor.x - this.offset.wrapper[0] - (this.handle.offsetWidth / 2),
-        Cursor.y - this.offset.wrapper[1] - (this.handle.offsetHeight / 2)
-      ]);
-    }
+    this.setTargetValueByOffset([
+      Cursor.x - this.offset.wrapper[0] - (this.handle.offsetWidth / 2),
+      Cursor.y - this.offset.wrapper[1] - (this.handle.offsetHeight / 2)
+    ]);
   },
   stopTap: function() {
     if (this.disabled || !this.tapping) {


### PR DESCRIPTION
Allows a user to enabled or disable the clicking of steps. 
Clicking on the track won't allow the handle to move when the enableStepClick option is set to false, otherwise
the normal behavior will work.
