### PR TITLE
fix bg rAF

### DIFF
--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -612,8 +612,8 @@ Dragdealer.prototype = {
     }
     if (Math.abs(diff[0]) > this.valuePrecision[0] ||
         Math.abs(diff[1]) > this.valuePrecision[1]) {
-      this.value.current[0] += diff[0] * this.options.speed * this.timeOffset / 25;
-      this.value.current[1] += diff[1] * this.options.speed * this.timeOffset / 25;
+      this.value.current[0] += diff[0] * Math.min(this.options.speed * this.timeOffset / 25, 1);
+      this.value.current[1] += diff[1] * Math.min(this.options.speed * this.timeOffset / 25, 1);
     } else {
       this.groupCopy(this.value.current, this.value.target);
     }


### PR DESCRIPTION
when rAF is paused (e.g. browser tab is put to background) and then later on continued, diff factor could increase above 1 and thus animation would be quite weird (approached target value from other direction)