### PR TITLE
Change translate to translate 3D. Introduced a notion of delta after dragging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 sauce_connect.log*
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 sauce_connect.log*
-.idea

--- a/spec/callbacksSpec.js
+++ b/spec/callbacksSpec.js
@@ -170,7 +170,7 @@ describe("Dragdealer callbacks", function() {
       helpers.drop('square-slider');
 
       expect(dragStopCallback.calls.length).toEqual(1);
-      expect(dragStopCallback).toHaveBeenCalledWith(0.5, 0.25);
+      expect(dragStopCallback).toHaveBeenCalledWith(0.5, 0.25, 200);
     });
 
     it("with projected values on drop with slide", function() {
@@ -184,7 +184,7 @@ describe("Dragdealer callbacks", function() {
       helpers.drop('square-slider');
 
       expect(dragStopCallback.calls.length).toEqual(1);
-      expect(dragStopCallback).toHaveBeenCalledWith(0.25, 0.125);
+      expect(dragStopCallback).toHaveBeenCalledWith(0.25, 0.125, 20);
     });
 
     it("with projected values on drop with slide to steps", function() {
@@ -202,7 +202,7 @@ describe("Dragdealer callbacks", function() {
       helpers.drop('simple-slider');
 
       expect(dragStopCallback.calls.length).toEqual(1);
-      expect(dragStopCallback).toHaveBeenCalledWith(0.4, 0);
+      expect(dragStopCallback).toHaveBeenCalledWith(0.4, 0,30);
     });
 
   });

--- a/spec/callbacksSpec.js
+++ b/spec/callbacksSpec.js
@@ -170,7 +170,7 @@ describe("Dragdealer callbacks", function() {
       helpers.drop('square-slider');
 
       expect(dragStopCallback.calls.length).toEqual(1);
-      expect(dragStopCallback).toHaveBeenCalledWith(0.5, 0.25, 200);
+      expect(dragStopCallback).toHaveBeenCalledWith(0.5, 0.25, [0.5, 0.25]);
     });
 
     it("with projected values on drop with slide", function() {
@@ -184,7 +184,7 @@ describe("Dragdealer callbacks", function() {
       helpers.drop('square-slider');
 
       expect(dragStopCallback.calls.length).toEqual(1);
-      expect(dragStopCallback).toHaveBeenCalledWith(0.25, 0.125, 20);
+      expect(dragStopCallback).toHaveBeenCalledWith(0.25, 0.125, [0.05, 0.025]);
     });
 
     it("with projected values on drop with slide to steps", function() {
@@ -202,7 +202,7 @@ describe("Dragdealer callbacks", function() {
       helpers.drop('simple-slider');
 
       expect(dragStopCallback.calls.length).toEqual(1);
-      expect(dragStopCallback).toHaveBeenCalledWith(0.4, 0,30);
+      expect(dragStopCallback).toHaveBeenCalledWith(0.4, 0, [0.075, 0]);
     });
 
   });

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -552,16 +552,15 @@ Dragdealer.prototype = {
     this.callDragStartCallback();
   },
   stopDrag: function() {
-    var delta;
     if (this.disabled || !this.dragging) {
       return;
     }
     this.dragging = false;
-    if (this.options.horizontal) {
-      delta = Cursor.x - this.oldCursor.x;
-    } else {
-      delta = Cursor.y - this.oldCursor.y;
-    }
+    var deltaX = this.bounds.availWidth === 0 ? 0 :
+          ((Cursor.x - this.oldCursor.x) / this.bounds.availWidth),
+        deltaY = this.bounds.availHeight === 0 ? 0 :
+          ((Cursor.y - this.oldCursor.y) / this.bounds.availHeight),
+        delta = [deltaX, deltaY];
 
     var target = this.groupClone(this.value.current);
     if (this.options.slide) {

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -245,6 +245,7 @@ Dragdealer.prototype = {
       current: [0, 0],
       target: [0, 0]
     };
+    this.oldCursor = {x: 0, y: 0};
     this.change = [0, 0];
     this.stepRatios = this.calculateStepRatios();
 
@@ -488,6 +489,9 @@ Dragdealer.prototype = {
       this.getStepNumber(this.value.target[1])
     ];
   },
+  getStepWidth: function () {
+    return Math.abs(this.bounds.availWidth / this.options.steps);
+  },
   getValue: function() {
     return this.value.target;
   },
@@ -537,6 +541,7 @@ Dragdealer.prototype = {
     this.dragging = true;
     this.setWrapperOffset();
 
+    this.oldCursor = {x: Cursor.x, y: Cursor.y};
     this.offset.mouse = [
       Cursor.x - Position.get(this.handle)[0],
       Cursor.y - Position.get(this.handle)[1]
@@ -547,10 +552,16 @@ Dragdealer.prototype = {
     this.callDragStartCallback();
   },
   stopDrag: function() {
+    var delta;
     if (this.disabled || !this.dragging) {
       return;
     }
     this.dragging = false;
+    if (this.options.horizontal) {
+      delta = Cursor.x - this.oldCursor.x;
+    } else {
+      delta = Cursor.y - this.oldCursor.y;
+    }
 
     var target = this.groupClone(this.value.current);
     if (this.options.slide) {
@@ -560,7 +571,7 @@ Dragdealer.prototype = {
     }
     this.setTargetValue(target);
     this.wrapper.className = this.wrapper.className.replace(' ' + this.options.activeClass, '');
-    this.callDragStopCallback();
+    this.callDragStopCallback(delta);
   },
   callAnimationCallback: function() {
     var value = this.value.current;
@@ -584,9 +595,9 @@ Dragdealer.prototype = {
       this.options.dragStartCallback.call(this, this.value.target[0], this.value.target[1]);
     }
   },
-  callDragStopCallback: function() {
+  callDragStopCallback: function(delta) {
     if (typeof(this.options.dragStopCallback) == 'function') {
-      this.options.dragStopCallback.call(this, this.value.target[0], this.value.target[1]);
+      this.options.dragStopCallback.call(this, this.value.target[0], this.value.target[1], delta);
     }
   },
   animateWithRequestAnimationFrame: function (time) {

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -673,10 +673,10 @@ Dragdealer.prototype = {
     var transform = '';
     if (this.options.css3 && StylePrefix.transform) {
       if (this.options.horizontal) {
-        transform += 'translate3d(' + this.offset.current[0] + 'px, 0, 0)';
+        transform += 'translateX(' + this.offset.current[0] + 'px)';
       }
       if (this.options.vertical) {
-        transform += ' translate3d(0, ' + this.offset.current[1] + 'px, 0)';
+        transform += ' translateY(' + this.offset.current[1] + 'px)';
       }
       this.handle.style[StylePrefix.transform] = transform;
       return;

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -245,7 +245,7 @@ Dragdealer.prototype = {
       current: [0, 0],
       target: [0, 0]
     };
-    this.oldCursor = {x: 0, y: 0};
+    this.dragStartPosition = {x: 0, y: 0};
     this.change = [0, 0];
     this.stepRatios = this.calculateStepRatios();
 
@@ -541,7 +541,7 @@ Dragdealer.prototype = {
     this.dragging = true;
     this.setWrapperOffset();
 
-    this.oldCursor = {x: Cursor.x, y: Cursor.y};
+    this.dragStartPosition = {x: Cursor.x, y: Cursor.y};
     this.offset.mouse = [
       Cursor.x - Position.get(this.handle)[0],
       Cursor.y - Position.get(this.handle)[1]
@@ -557,9 +557,9 @@ Dragdealer.prototype = {
     }
     this.dragging = false;
     var deltaX = this.bounds.availWidth === 0 ? 0 :
-          ((Cursor.x - this.oldCursor.x) / this.bounds.availWidth),
+          ((Cursor.x - this.dragStartPosition.x) / this.bounds.availWidth),
         deltaY = this.bounds.availHeight === 0 ? 0 :
-          ((Cursor.y - this.oldCursor.y) / this.bounds.availHeight),
+          ((Cursor.y - this.dragStartPosition.y) / this.bounds.availHeight),
         delta = [deltaX, deltaY];
 
     var target = this.groupClone(this.value.current);

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -662,10 +662,10 @@ Dragdealer.prototype = {
     var transform = '';
     if (this.options.css3 && StylePrefix.transform) {
       if (this.options.horizontal) {
-        transform += 'translateX(' + this.offset.current[0] + 'px)';
+        transform += 'translate3d(' + this.offset.current[0] + 'px, 0, 0)';
       }
       if (this.options.vertical) {
-        transform += ' translateY(' + this.offset.current[1] + 'px)';
+        transform += ' translate3d(0, ' + this.offset.current[1] + 'px, 0)';
       }
       this.handle.style[StylePrefix.transform] = transform;
       return;


### PR DESCRIPTION
This merge requests has 2 main changes:

1. Change translateX to translate3d because it is GPU accelerated on modern webkit browsers.

2.  Introduced a notion of delta in the stop drag callback. Delta is the difference between the old position of the cursor and the new position of the cursor. This is needed in order for our application's internal wrapper of the dragdealer to allow swiping for smaller  finger movements (for example, when delta is only 30px)