### PR TITLE
fix issue with click-events being prevented when a device sends mouse-move events along with the click

### DIFF
--- a/spec/eventsSpec.js
+++ b/spec/eventsSpec.js
@@ -37,6 +37,32 @@ describe("Click events inside handle", function() {
     expect(clickHandler.calls.length).toEqual(1);
     expect(clickHandler.calls[0].args[0].isDefaultPrevented()).toBe(false);
   });
+
+  it("should be passed through if mouse moving without changing position", function() {
+    var clickHandler = jasmine.createSpy();
+    var someX = 42;
+    var someY = 42;
+    helpers.initDragdealer('content-slider');
+
+    var wrapperPosition = $('#content-slider').offset();
+
+    $('#content-slider').click(clickHandler);
+    $('#content-slider .inner-button')
+        .simulate('mousemove',{ // to have a consistent startDrag position
+          clientX: someX,
+          clientY: someY
+        })
+        .simulate('mousedown')
+        .simulate('mousemove',{
+          clientX: someX,
+          clientY: someY
+        })
+        .simulate('mouseup')
+        .simulate('click');
+
+    expect(clickHandler.calls.length).toEqual(1);
+    expect(clickHandler.calls[0].args[0].isDefaultPrevented()).toBe(false);
+  });
 });
 
 describe("Previous DOM events", function() {

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -415,6 +415,11 @@ Dragdealer.prototype = {
     this.startDrag();
   },
   onDocumentMouseMove: function(e) {
+    if((e.clientX - this.dragStartPosition.x) === 0 &&  (e.clientY - this.dragStartPosition.y) === 0) {
+      // This is required on some Windows8 machines that get mouse move events without actual mouse movement
+      return;
+    }
+
     Cursor.refresh(e);
     if (this.dragging) {
       this.activity = true;

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -415,7 +415,8 @@ Dragdealer.prototype = {
     this.startDrag();
   },
   onDocumentMouseMove: function(e) {
-    if((e.clientX - this.dragStartPosition.x) === 0 &&  (e.clientY - this.dragStartPosition.y) === 0) {
+    if ((e.clientX - this.dragStartPosition.x) === 0 &&
+        (e.clientY - this.dragStartPosition.y) === 0) {
       // This is required on some Windows8 machines that get mouse move events without actual mouse movement
       return;
     }


### PR DESCRIPTION
We discovered that some devices with Windows 8 seem to send a mouseMove event when clicking. 
DragDealer calls `preventDefault` on those, preventing any clickhandlers further up in the chain. 

This change detects those events by checking if `clientX` and `clientY` are different from the `dragStart` position on mouseMove and ignores them. 