### PR TITLE
Fix UMD definition for commonjs

### DIFF
--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -10,6 +10,11 @@
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
     define(factory);
+  } else if (typeof module === 'object' && module.exports) {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like enviroments that support module.exports,
+    // like Node.
+    module.exports.Dragdealer = factory();
   } else {
     // Browser globals
     root.Dragdealer = factory();


### PR DESCRIPTION
When loading `src/dragdealer.js` via browserify with a babelify transform the library will throw, because babel will transform `this` in UMD into `undefined`:
``` javascript
(function (root, factory) {
  if (typeof define === 'function' && define.amd) {
    // AMD. Register as an anonymous module.
    define(factory);
  } else {
    // Browser globals
    root.Dragdealer = factory();
  }
})(undefined, function () {
```

By extending the UMD definition for CommonJS syntax the issue is solved.
You can create a test case by creating a file `test.js` with content `require('./src/dragdealer')` and executing `browserify --require test.js -o bundle.js --transform babelify` and load the `bundle.js` in a browser.