### PR TITLE
add methods to toggle keypresses

### DIFF
--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -483,6 +483,12 @@ Dragdealer.prototype = {
     this.disabled = true;
     this.handle.className += ' disabled';
   },
+  startListeningToKeys: function() {
+      addEventListener(document, 'keydown', this.onKeyPress);
+  },
+  stopListeningToKeys: function() {
+      removeEventListener(document, 'keydown', this.onKeyPress);
+  },
   reflow: function() {
     this.setWrapperOffset();
     this.bounds = this.calculateBounds();


### PR DESCRIPTION
Simple toggle so we can turn keydown binding on and off. Useful for accessibility. 

```dragdealer.handle.addEventListener('focus', dragdealer.startListeningToKeys.bind(dragdealer));```