### PR TITLE
Changed startTap() behavior when option.snap=true

### DIFF
--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -537,17 +537,9 @@ Dragdealer.prototype = {
       //If we have a snap slider, it makes more sense that when a user click on the wrapper
       //the handle will snap to the closest step, instead of moving with a ratio until it
       //reachs the step.
-      //Check for the closest stepRatio
+      //Check for the closest step and set it as the current value
       var cursorRatio = (Cursor.x - this.offset.wrapper[0])/this.bounds.availWidth;
-      var closestStep = 1;
-      var stepDistance = Math.abs(cursorRatio - this.stepRatios[0]);
-      for(var i = 1; i < this.stepRatios.length; i++){
-        if(Math.abs(cursorRatio - this.stepRatios[i]) < stepDistance){
-          closestStep = i+1;
-          stepDistance = Math.abs(cursorRatio - this.stepRatios[i]);
-        }
-      }
-      this.setValue(this.stepRatios[closestStep-1], 0, true);
+      this.setValue(this.getClosestStep(cursorRatio), 0, true);
     } else {
       this.setTargetValueByOffset([
         Cursor.x - this.offset.wrapper[0] - (this.handle.offsetWidth / 2),

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -538,8 +538,9 @@ Dragdealer.prototype = {
       //the handle will snap to the closest step, instead of moving with a ratio until it
       //reachs the step.
       //Check for the closest step and set it as the current value
-      var cursorRatio = (Cursor.x - this.offset.wrapper[0])/this.bounds.availWidth;
-      this.setValue(this.getClosestStep(cursorRatio), 0, true);
+      var cursorXRatio = (Cursor.x - this.offset.wrapper[0])/this.bounds.availWidth;
+      var cursorYRatio = (Cursor.y - this.offset.wrapper[1])/this.bounds.availHeight;
+      this.setValue(this.getClosestStep(cursorXRatio), this.getClosestStep(cursorYRatio), true);
     } else {
       this.setTargetValueByOffset([
         Cursor.x - this.offset.wrapper[0] - (this.handle.offsetWidth / 2),

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -533,13 +533,13 @@ Dragdealer.prototype = {
     this.setWrapperOffset();
 
     //Check if the slider is a stepped snap slider:
-    if(this.options.snap && this.options.steps){
+    if (this.options.snap && this.options.steps) {
       //If we have a snap slider, it makes more sense that when a user click on the wrapper
       //the handle will snap to the closest step, instead of moving with a ratio until it
-      //reachs the step.
+      //reaches the step.
       //Check for the closest step and set it as the current value
-      var cursorXRatio = (Cursor.x - this.offset.wrapper[0])/this.bounds.availWidth;
-      var cursorYRatio = (Cursor.y - this.offset.wrapper[1])/this.bounds.availHeight;
+      var cursorXRatio = (Cursor.x - this.offset.wrapper[0]) / this.bounds.availWidth;
+      var cursorYRatio = (Cursor.y - this.offset.wrapper[1]) / this.bounds.availHeight;
       this.setValue(this.getClosestStep(cursorXRatio), this.getClosestStep(cursorYRatio), true);
     } else {
       this.setTargetValueByOffset([

--- a/src/dragdealer.js
+++ b/src/dragdealer.js
@@ -532,10 +532,28 @@ Dragdealer.prototype = {
     this.tapping = true;
     this.setWrapperOffset();
 
-    this.setTargetValueByOffset([
-      Cursor.x - this.offset.wrapper[0] - (this.handle.offsetWidth / 2),
-      Cursor.y - this.offset.wrapper[1] - (this.handle.offsetHeight / 2)
-    ]);
+    //Check if the slider is a stepped snap slider:
+    if(this.options.snap && this.options.steps){
+      //If we have a snap slider, it makes more sense that when a user click on the wrapper
+      //the handle will snap to the closest step, instead of moving with a ratio until it
+      //reachs the step.
+      //Check for the closest stepRatio
+      var cursorRatio = (Cursor.x - this.offset.wrapper[0])/this.bounds.availWidth;
+      var closestStep = 1;
+      var stepDistance = Math.abs(cursorRatio - this.stepRatios[0]);
+      for(var i = 1; i < this.stepRatios.length; i++){
+        if(Math.abs(cursorRatio - this.stepRatios[i]) < stepDistance){
+          closestStep = i+1;
+          stepDistance = Math.abs(cursorRatio - this.stepRatios[i]);
+        }
+      }
+      this.setValue(this.stepRatios[closestStep-1], 0, true);
+    } else {
+      this.setTargetValueByOffset([
+        Cursor.x - this.offset.wrapper[0] - (this.handle.offsetWidth / 2),
+        Cursor.y - this.offset.wrapper[1] - (this.handle.offsetHeight / 2)
+      ]);
+    }
   },
   stopTap: function() {
     if (this.disabled || !this.tapping) {


### PR DESCRIPTION
When we have a slider that is restricted to steps and has the snap option set, it's more intuitive to think that when the user clicks the wrapper, the handle will jump straight to the closest step. The new code adds this behavior exclusively for this case (option.steps > 0 and option.snap == true). All the other cases behave as before, setting a target value depending on the distance from the mouse to the handle.